### PR TITLE
fix: improve install script for Clue app

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
+set -e # stop on first error
 
-pip install -r requirements.txt --break-system-packages
+# Install dependencies (better to use user scope or venv)
+pip install --user -r requirements.txt
+
+# Build the binary
 pyinstaller --onefile --noconfirm --name "clue" main.py
-sudo mv dist/clue /usr/bin/
+
+sudo mv dist/clue /usr/local/bin/
+
 rm -rf build dist clue.spec
-mkdir ~/clue_docs
-echo "Clue App installed successfully! You can run it using the command 'clue'".
+
+mkdir -p ~/clue_docs
+
+echo "✅ Clue App installed successfully! You can run it using the command: clue"

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import requests
+import getpass
 
 running = True
 pltform = sys.platform
@@ -13,7 +14,7 @@ if os.path.exists(USER_INFO_FILE):
     with open(USER_INFO_FILE, "r", encoding="utf-8") as f:
         username_for_path = f.read().strip()
 else:
-    username_for_path = input("Enter your username: ").strip()
+    username_for_path = getpass.getuser()
     with open(USER_INFO_FILE, "w", encoding="utf-8") as f:
         f.write(username_for_path)
 
@@ -21,11 +22,13 @@ DOC_DIR = os.path.expanduser(f"/home/{username_for_path}/clue_docs")
 os.makedirs(DOC_DIR, exist_ok=True)
 DOC_FILE = os.path.join(DOC_DIR, "doc.txt")
 
+
 def clear_console():
     if pltform == "linux":
         os.system("clear")
     elif pltform == "win32":
         os.system("cls")
+
 
 while running:
     if pltform == "win32":
@@ -77,4 +80,3 @@ while running:
 
     input("Press Enter to continue...")
     clear_console()
-


### PR DESCRIPTION
- Use /usr/local/bin instead of /usr/bin for binary placement
- Add error handling with
- Use  to avoid folder creation errors
- Avoid  to prevent system conflicts
- Clean up build artifacts safely